### PR TITLE
PENG-2112 Adde democluster build as step in release process

### DIFF
--- a/.github/workflows/build-and-publish-image.yaml
+++ b/.github/workflows/build-and-publish-image.yaml
@@ -1,9 +1,16 @@
-name: 'Build and Publish democluster to s3'
+name: "Build and Publish democluster to s3"
 
 on:
   push:
     branches:
       - main
+  workflow_dispatch:
+    inputs:
+      jobbergate_version:
+        description: The Jobbergate agent version
+        required: false
+        type: string
+        default: 4.3.1
 
 jobs:
   build-image-in-lxd:
@@ -19,6 +26,8 @@ jobs:
           poetry install
 
       - name: Build democluster
+        env:
+          JG_VERSION: ${{ github.event.inputs.jobbergate_version }}
         run: |
           poetry run image-factory build democluster
 
@@ -28,6 +37,6 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           AWS_DEFAULT_REGION: us-east-1
         run: |
-            aws s3 sync democluster/final \
-              s3://omnivector-public-assets/cloud-images/democluster/latest \
-              --acl public-read --follow-symlinks --delete 1> /dev/null
+          aws s3 sync democluster/final \
+            s3://omnivector-public-assets/cloud-images/democluster/latest \
+            --acl public-read --follow-symlinks --delete 1> /dev/null

--- a/democluster/Makefile
+++ b/democluster/Makefile
@@ -19,6 +19,9 @@ check-deps: ## Check deps needed to build the image
 
 .PHONY: init
 init: ## Run packer init .
+	@if [ ! -z "$JG_VERSION" ]; then\
+		sed -i 's/jobbergate-agent==[0-9]\+\.[0-9]\+\.[0-9]\+/jobbergate-agent==$(JG_VERSION)/' user-data;\
+    fi
 	${PACKER} init .
 
 .PHONY: stage0


### PR DESCRIPTION
# What
This PR implements changes in the GitHub and Makefile action to trigger the build process manually. The trigger takes a parameter for the jobbergate version at build time.

# Why
This is needed to build the democluster with specific jobbergate versions. It also allows the action to be triggered by third actions in Git Hub.

## Taskdetails: https://app.clickup.com/t/18022949/PENG-2112