### PR TITLE
fix the *multipass launch* command in the deploy-democluster.sh script

### DIFF
--- a/public-scripts/deploy-democluster.sh
+++ b/public-scripts/deploy-democluster.sh
@@ -112,7 +112,7 @@ EOF
   mkdir -p $HOME/democluster/tmp
 
   cat /tmp/cloud-init.yaml | multipass launch -c$(nproc) \
-  -m4GB \
+  -m4G \
   --mount=$HOME/democluster:/home/ubuntu/democluster \
   -n democluster-`echo "$CLIENT_ID" | sed 's/-[0-9a-f]\{8\}-[0-9a-f]\{4\}-4[0-9a-f]\{3\}-[89abAB][0-9a-f]\{3\}-[0-9a-f]\{12\}//'` \
   $IMAGE_ORIGIN \


### PR DESCRIPTION
This PR fixes the `deploy-democluster.sh` command in order to fix the `multipass launch` command. Essentially, the command was erroring because of the argument `-m` having a unknown character by the CLI.