### PR TITLE
fix(democluster): fix the permission of the file `acct_gather.conf`.

### DIFF
--- a/democluster/user-data
+++ b/democluster/user-data
@@ -350,7 +350,7 @@ write_files:
 
 - path: /etc/slurm/acct_gather.conf
   owner: root:root
-  permissions: '0600'
+  permissions: '0644'
   content: |
     ProfileInfluxDBDatabase=slurm-job-metrics
     ProfileInfluxDBDefault=All


### PR DESCRIPTION
This PR bumps the permission of the `acct_gather.conf` file from 0600 to 0644. This permission was preventing slurmctld to start, consequently the democluster was buggy.