### PR TITLE
fix: set the `influx-dsn` configuration in the **jobbergate-agent** snap

### DIFF
--- a/public-scripts/deploy-democluster.sh
+++ b/public-scripts/deploy-democluster.sh
@@ -108,6 +108,7 @@ runcmd:
   - snap set jobbergate-agent oidc-client-secret=$CLIENT_SECRET
   - snap set jobbergate-agent task-jobs-interval-seconds=30
   - snap set jobbergate-agent x-slurm-user-name=root
+  - snap set jobbergate-agent influx-dsn=influxdb://slurm:rats@localhost:8086/slurm-job-metrics
   - snap start vantage-agent.start
   - snap start jobbergate-agent.start
 EOF


### PR DESCRIPTION
This PR modifies the **democluster** **user-data** file in order to set the configuration `influx-dsn` for the **jobbergate-agent** snap. This is necessary so the job metric integration is properly started by the agent.