### PR TITLE
chore: PENG-2681 Removed unneeded systemd config for agents

### DIFF
--- a/democluster/user-data
+++ b/democluster/user-data
@@ -171,44 +171,6 @@ write_files:
     =mg0I
     -----END PGP PUBLIC KEY BLOCK-----
 
-- path: /usr/lib/systemd/system/jobbergate-agent.service
-  owner: root:root
-  permissions: '0644'
-  content: |
-    [Unit]
-    Description=jobbergate-agent
-    After=network.target
-
-    [Service]
-    Type=simple
-    User=root
-    Group=root
-    WorkingDirectory=/srv/jobbergate-agent-venv
-    ExecStart=/srv/jobbergate-agent-venv/bin/jg-run
-
-    [Install]
-    Alias=jobbergate-agent.service
-    WantedBy=multi-user.target
-
-- path: /usr/lib/systemd/system/vantage-agent.service
-  owner: root:root
-  permissions: '0644'
-  content: |
-    [Unit]
-    Description=vantage-agent
-    After=network.target
-
-    [Service]
-    Type=simple
-    User=root
-    Group=root
-    WorkingDirectory=/srv/vantage-agent-venv
-    ExecStart=/srv/vantage-agent-venv/bin/vtg-run
-
-    [Install]
-    Alias=vantage-agent.service
-    WantedBy=multi-user.target
-
 - path: /etc/slurm/slurmrestd.conf
   owner: root:root
   permissions: '0600'


### PR DESCRIPTION
The agents are now installed through snaps, so the systemd configuration for them is not needed.

This will also trigger a new build for the democluster when it is merged.